### PR TITLE
Allow "HOOD" as an import column alias for sim_inst

### DIFF
--- a/manage/constants.py
+++ b/manage/constants.py
@@ -98,6 +98,7 @@ COLUMN_NAMES = {
     "SIMULATED INSTRUMENT": 'sim_inst',
     'SIMINSTR': 'sim_inst',
     "SIM INSTR": 'sim_inst',
+    "HOOD": 'sim_inst',
 				
     "STUDENT": 'student',
     "INSTRUCTOR":'instructor',


### PR DESCRIPTION
Since the logbook display webpage uses "Hood" as the label for this column, it makes sense to allow that same name when importing a CSV file.  I was having difficulty importing this logbook column because I had been using the wrong name for it.
