### PR TITLE
fix incorrect page title for bar graphs

### DIFF
--- a/graphs/templates/bargraphs.html
+++ b/graphs/templates/bargraphs.html
@@ -16,7 +16,7 @@
 	
 {% endblock %}
 
-{% block title %}Line Graphs ({{ request.display_user.username }}){% endblock %}
+{% block title %}Bar Graphs ({{ request.display_user.username }}){% endblock %}
 
 {% block canvas %}
     <select id="func">


### PR DESCRIPTION
This addresses user-reported bug from Google Groups:
https://groups.google.com/forum/#!topic/flightloggin/K9ByXIHdvTc
